### PR TITLE
Standardization and systemd fix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,15 +1,7 @@
 ---
-driver:
-  name: vagrant
-
 provisioner:
   name: chef_solo
   data_bags_path: test/integration/data_bags
-
-platforms:
-  - name: ubuntu-12.04
-  - name: centos-6.6
-  - name: centos-7.1
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Description
 
 Manages ucarp IP failover on Linux.
 
+ucarp is a portable implemenation of the Common Address Redundacny Protocol
+which allows multiple hosts on the same local area network to share a set of IP
+addresses to provide automatic failover.
+
 Requirements
 ============
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,130 @@
+# Rake tasks
+
+require 'rake'
+
+require 'fileutils'
+require 'base64'
+require 'chef/encrypted_data_bag_item'
+require 'json'
+require 'openssl'
+
+snakeoil_file_path = 'test/integration/data_bags/certificates/snakeoil.json'
+encrypted_data_bag_secret_path = 'test/integration/encrypted_data_bag_secret'
+
+##
+# Run command wrapper
+def run_command(command)
+  if File.exist?('Gemfile.lock')
+    sh %(bundle exec #{command})
+  else
+    sh %(chef exec #{command})
+  end
+end
+
+##
+# Create a self-signed SSL certificate
+#
+def gen_ssl_cert
+  name = OpenSSL::X509::Name.new [
+    ['C', 'US'],
+    ['ST', 'Oregon'],
+    ['CN', 'OSU Open Source Lab'],
+    ['DC', 'example']
+  ]
+  key = OpenSSL::PKey::RSA.new 2048
+
+  cert = OpenSSL::X509::Certificate.new
+  cert.version = 2
+  cert.serial = 2
+  cert.subject = name
+  cert.public_key = key.public_key
+  cert.not_before = Time.now
+  cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60 # 1 years validity
+
+  # Self-sign the Certificate
+  cert.issuer = name
+  cert.sign(key, OpenSSL::Digest::SHA1.new)
+
+  return cert, key
+end
+
+##
+# Create a data bag item (with the id of snakeoil) containing a self-signed SSL
+#  certificate
+#
+def ssl_data_bag_item
+  cert, key = gen_ssl_cert
+  Chef::DataBagItem.from_hash(
+    'id' => 'snakeoil',
+    'cert' => cert.to_pem,
+    'key' => key.to_pem
+  )
+end
+
+##
+# Create the integration tests directory if it doesn't exist
+#
+directory 'test/integration'
+
+##
+# Generates a 512 byte random sequence and write it to
+#  'test/integration/encrypted_data_bag_secret'
+#
+file encrypted_data_bag_secret_path => 'test/integration' do
+  encrypted_data_bag_secret = OpenSSL::Random.random_bytes(512)
+  open encrypted_data_bag_secret_path, 'w' do |io|
+    io.write Base64.encode64(encrypted_data_bag_secret)
+  end
+end
+
+##
+# Create the certificates data bag if it doesn't exist
+#
+directory 'test/integration/data_bags/certificates' => 'test/integration'
+
+##
+# Create the encrypted snakeoil certificate under
+#  test/integration/data_bags/certificates
+#
+file snakeoil_file_path => [
+  'test/integration/data_bags/certificates',
+  'test/integration/encrypted_data_bag_secret'
+] do
+
+  encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
+    encrypted_data_bag_secret_path
+  )
+
+  encrypted_snakeoil_cert = Chef::EncryptedDataBagItem.encrypt_data_bag_item(
+    ssl_data_bag_item, encrypted_data_bag_secret
+  )
+
+  open snakeoil_file_path, 'w' do |io|
+    io.write JSON.pretty_generate(encrypted_snakeoil_cert)
+  end
+end
+
+desc 'Create an Encrypted Databag Snakeoil SSL Certificate'
+task snakeoil: snakeoil_file_path
+
+desc 'Create an Encrypted Databag Secret'
+task secret_file: encrypted_data_bag_secret_path
+
+require 'rubocop/rake_task'
+desc 'Run RuboCop (style) tests'
+RuboCop::RakeTask.new(:style)
+
+desc 'Run FoodCritic (lint) tests'
+task :lint do
+    run_command('foodcritic --epic-fail any .')
+end
+
+desc 'Run RSpec (unit) tests'
+task :unit do
+    run_command('rspec')
+end
+
+desc 'Run all tests'
+task test: [:style, :lint, :unit]
+
+task default: :test

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,7 +8,7 @@ default['ucarp']['netmask'] = '255.255.255.0'
 default['ucarp']['interface'] = 'eth0'
 default['ucarp']['bonded_interfaces'] = %w(eth0 eth1)
 default['ucarp']['bond_mode'] = 5
-default['ucarp']['init_type']  = value_for_platform(
+default['ucarp']['init_type'] = value_for_platform(
   'centos' => {
     '~> 6.0' => 'upstart',
     '~> 7.0' => 'systemd'
@@ -16,4 +16,5 @@ default['ucarp']['init_type']  = value_for_platform(
   'debian' => {
     '~> 8.0' => 'systemd'
   },
-  'default' => 'upstart')
+  'default' => 'upstart'
+)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,12 @@ license          "Apache 2.0"
 description      "Installs/Configures ucarp"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.2"
+issues_url       "https://github.com/osuosl-cookbooks/ucarp/issues"
+source_url       "https://github.com/osuosl-cookbooks/ucarp"
 
-depends 'yum-epel'
+depends 'yum-epel','< 3.0'
+depends 'apt'
 
 supports 'debian'
 supports 'ubuntu'
+supports 'centos'

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -35,15 +35,6 @@ if platform_family?('rhel')
     notifies :restart, 'service[ucarp]'
   end
 
-  paths = %w(/etc/systemd/system /etc/systemd/system/multi-user.target.wants)
-  # workaround for systemd and template services
-  paths.each do |pth|
-    link "#{pth}/ucarp@vip-#{ucarp_databag['vip_id']}.service" do
-      to '/usr/lib/systemd/system/ucarp@.service'
-      only_if { node['ucarp']['init_type'] == 'systemd' }
-    end
-  end
-
   service 'ucarp' do
     case node['ucarp']['init_type']
     when 'systemd'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,17 +22,17 @@ include_recipe 'yum-epel' if platform_family?('rhel')
 package 'ucarp'
 
 unless platform_family?('rhel')
-  if node['ucarp']['master']
-    skew = node['ucarp']['advskew']
-  else
-    skew = node['ucarp']['advskew'] + 99
-  end
+  skew = if node['ucarp']['master']
+           node['ucarp']['advskew']
+         else
+           node['ucarp']['advskew'] + 99
+         end
 
   template '/etc/network/interfaces' do
     source 'interfaces.erb'
     owner 'root'
     group 'root'
-    mode 0644
+    mode '0644'
     variables(
       vid: node['ucarp']['vid'],
       vip: node['ucarp']['vip'],
@@ -47,7 +47,7 @@ unless platform_family?('rhel')
     )
     notifies :restart, 'service[networking]', :immediately
 
-    if node['ucarp']['interface'].match(/bond/)
+    if node['ucarp']['interface'] =~ /bond/
       node['ucarp']['bonded_interfaces'].each do |interface|
         if node['network']['interfaces'].include?(interface)
           notifies :run, "execute[flush ip on #{interface}]", :immediately

--- a/spec/databag_spec.rb
+++ b/spec/databag_spec.rb
@@ -1,0 +1,18 @@
+require_relative 'spec_helper'
+
+describe 'ucarp::data_bag' do
+  ALL_PLATFORMS.each do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.normal['ucarp']['data_bag']['cluster'] = 'lb1'
+        node.normal['ucarp']['init_type'] = 'systemd'
+      end.converge(described_recipe)
+    end
+
+    include_context 'common_stubs'
+
+    it do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,29 @@
+require_relative 'spec_helper'
+
+describe 'ucarp::default' do
+  ALL_PLATFORMS.each do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.normal['platform_family'] = 'rhel'
+      end.converge(described_recipe)
+    end
+
+    context 'on both rhel and non-rhel distros' do
+      it do
+        expect(chef_run).to install_package('ucarp')
+      end
+    end
+
+    it do
+      resource = chef_run.service('networking')
+      expect(resource).to do_nothing
+    end
+
+    it do
+      template_resource = chef_run.template('/etc/network/interfaces')
+      expect(template_resource).to notify(
+        'service[networking]'
+      ).to(:restart).immediately
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,48 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+ChefSpec::Coverage.start! { add_filter 'ucarp' }
+
+CENTOS_7 = {
+  platform: 'centos',
+  version: '7.3',
+  platform_family: 'rhel'
+}.freeze
+
+CENTOS_6 = {
+  platform: 'centos',
+  version: '6.8',
+  platform_family: 'rhel'
+}.freeze
+
+DEBIAN_8 = {
+  platform: 'debian',
+  version: '8.4'
+}.freeze
+
+ALL_PLATFORMS = [
+  CENTOS_6,
+  CENTOS_7,
+  DEBIAN_8
+].freeze
+
+RSpec.configure do |config|
+  config.log_level = :fatal
+end
+
+shared_context 'common_stubs' do
+  before do
+    stub_command 'ip addr flush dev eth0'
+    stub_command 'ip addr flush dev eth1'
+    stub_command 'flush ip on eth0'
+    stub_command 'flush ip on eth1'
+
+    stub_data_bag_item('ucarp', 'lb1').and_return(
+      id: 'vip-lb1',
+      vip_id: '001',
+      vip_address: '192.0.2.4',
+      bind_interface: 'eth0',
+      password: 'secret'
+    )
+  end
+end

--- a/test/integration/data_bag/serverspec/server_spec.rb
+++ b/test/integration/data_bag/serverspec/server_spec.rb
@@ -9,3 +9,11 @@ describe file('/etc/ucarp/vip-001.conf') do
   its(:content) { should match(/VIP\_ADDRESS=192.0.2.4/) }
   its(:content) { should match(/PASSWORD=secret/) }
 end
+
+describe package('ucarp') do
+  it { should be_installed }
+end
+
+describe service('ucarp@vip-001') do
+  it { should be_enabled }
+end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -7,5 +7,5 @@ describe package('ucarp') do
 end
 
 describe service('ucarp') do
-  it { shoule be_enabled }
+  it { should be_enabled }
 end


### PR DESCRIPTION
Fixes the systemd problem described in #8 and also addresses the standardization task, partially.

Please note:

* rspec will fail because our fauxhai does not have support for 6.8 and upstream fauxhai does not support 7.3
* enabling ucarp service does not work on CentOS and Debian both.

