### PR TITLE
Add ucarp::remove

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,4 +14,12 @@ suites:
       ucarp:
         data_bag:
           cluster: test
+  - name: remove
+    run_list:
+      - recipe[ucarp::data_bag]
+      - recipe[ucarp::remove]
+    attributes:
+      ucarp:
+        data_bag:
+          cluster: test
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,18 @@ AllCops:
     - '**Cheffile'
   Exclude:
     - 'metadata.rb'
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
+Metrics/LineLength:
+  Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120
+
+Metrics/BlockLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ addresses to provide automatic failover.
 Requirements
 ============
 
-Currently supports Debian and Ubuntu style networking.
+Platforms
+-----------
+- CentOS 6
+- CentOS 7
 
 Attributes
 ==========

--- a/files/default/ucarp
+++ b/files/default/ucarp
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Source function library.
+. /etc/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+# Check that networking is up.
+#[ ${NETWORKING} = "no" ] && exit 0
+
+get_files() {
+    _cfg=$1
+    FILES=`find ${CONFDIR} -maxdepth 1 -type f -name "${_cfg}.conf" \
+        -printf "%f\n" | egrep '^vip-[[:digit:]]+\.conf$' | LC_COLLATE="C" sort`
+}
+
+prog=$"common address redundancy protocol daemon"
+LOGGER="/usr/bin/logger -p daemon.notice -t ucarp"
+CONFDIR=/etc/ucarp
+UPSCRIPT=/usr/libexec/ucarp/vip-up
+DOWNSCRIPT=/usr/libexec/ucarp/vip-down
+
+config=$2
+
+start() {
+    RETVAL=-1
+    VIP_RETVAL=0
+
+    echo -n $"Starting ${prog}: "
+
+    get_files $config
+
+    if [ -z "${FILES}" ]; then
+        ${LOGGER} "no virtual addresses are configured in ${CONFDIR}"
+        failure
+        RETVAL=1
+    else
+        for FILE in ${FILES}; do
+            # Check that the file name gives us an ID between 1 and 255
+            ID=`echo ${FILE}| sed 's/^vip-\(.*\).conf/\1/'`
+            if [ ${ID} -lt 1 -o ${ID} -gt 255 ]; then
+                ${LOGGER} "ID out of range (1-255) for ${FILE}, skipped VIP ID ${ID}"
+                continue
+            fi
+
+            #unset PASSWORD BIND_INTERFACE SOURCE_ADDRESS VIP_ADDRESS OPTIONS
+            # Source ucarp settings
+            . ${CONFDIR}/vip-common.conf
+            . ${CONFDIR}/${FILE}
+            TMP_RETVAL=0
+
+            if [ -z "${PASSFILE}" ]; then
+                ${LOGGER} "no PASSFILE found for ${FILE}, skipped VIP ID ${ID}"
+                TMP_RETVAL=1
+            fi
+            if [ -z "${BIND_INTERFACE}" ]; then
+                ${LOGGER} "no BIND_INTERFACE found for ${FILE}, skipped VIP ID ${ID}"
+                TMP_RETVAL=1
+            fi
+            if [ -z "${SOURCE_ADDRESS}" ]; then
+                ${LOGGER} "no SOURCE_ADDRESS found for ${FILE}, skipped VIP ID ${ID}"
+                TMP_RETVAL=1
+            fi
+            if [ -z "${VIP_ADDRESS}" ]; then
+                ${LOGGER} "no VIP_ADDRESS found for ${FILE}, skipped VIP ID ${ID}"
+                TMP_RETVAL=1
+            fi
+
+            # If one of more of the above failed, skip the daemon launch
+            if [ ${TMP_RETVAL} -ne 0 ]; then
+                VIP_RETVAL=1
+                continue
+            fi
+
+            [ ${RETVAL} -eq -1 ] && RETVAL=0
+            daemon /usr/sbin/ucarp --daemonize --interface=${BIND_INTERFACE} --passfile=${PASSFILE} --srcip=${SOURCE_ADDRESS} --vhid=${ID} --addr=${VIP_ADDRESS} ${OPTIONS} --upscript=$UPSCRIPT --downscript=$DOWNSCRIPT >/dev/null
+            LAUNCH_RETVAL=$?
+            [ ${LAUNCH_RETVAL} -ne 0 ] && RETVAL=1
+        done
+
+        # failure/success or warning if launch worked with some vip errors
+        if [ ${RETVAL} -eq 0 -a ${VIP_RETVAL} -eq 0 ]; then
+            ${LOGGER} "all ucarp configurations were applied successfully"
+            success
+            touch /var/lock/subsys/ucarp
+        elif [ ${RETVAL} -eq 0 -a ${VIP_RETVAL} -eq 1 ]; then
+            ${LOGGER} "error in one or more of the ucarp configurations"
+            warning
+        else
+           ${LOGGER} "error running one or more of the ucarp daemon instances"
+            failure
+        fi
+    fi
+    echo
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc /usr/sbin/ucarp >/dev/null
+    RETVAL=$?
+
+    # With "--shutdown" in the default OPTIONS, the down script is called
+    # when ucarp is stopped, so IP addresses are released, no "leftovers".
+
+    # failure/success (no warning, too complicated to handle properly)
+    if [ ${RETVAL} -eq 1 ]; then
+        ${LOGGER} "it seems like no ucarp daemon were running"
+        failure
+    else
+        ${LOGGER} "all ucarp daemons stopped and IP addresses unassigned"
+        success
+        rm -f /var/lock/subsys/ucarp
+    fi
+    echo
+}
+
+# See how we were called.
+#case "$1" in
+#    start)
+#        start
+#        ;;
+#    stop)
+#        stop
+#        ;;
+#    restart)
+#        stop
+#        start
+#        ;;
+#    condrestart)
+#        if [ -f /var/lock/subsys/ucarp ]; then
+#            stop
+#            start
+#        fi
+#        ;;
+#    status)
+#        status /usr/sbin/ucarp
+#        ;;
+#    *)
+#        echo $"Usage: $0 {start|stop|restart|condrestart|status}"
+#        exit 1
+#esac
+start
+exit $RETVAL

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,8 +9,5 @@ issues_url       "https://github.com/osuosl-cookbooks/ucarp/issues"
 source_url       "https://github.com/osuosl-cookbooks/ucarp"
 
 depends 'yum-epel','< 3.0'
-depends 'apt'
 
-supports 'debian'
-supports 'ubuntu'
 supports 'centos'

--- a/recipes/data_bag.rb
+++ b/recipes/data_bag.rb
@@ -25,23 +25,29 @@ rescue
   raise "Could not find data bag for #{node['ucarp']['data_bag']['cluster']}"
 end
 
-if platform_family?('rhel')
-  template "/etc/ucarp/vip-#{ucarp_databag['vip_id']}.conf" do
-    source 'vip.conf.erb'
-    owner 'root'
-    group 'root'
-    mode '0644'
-    variables ucarp_databag.to_hash
-    notifies :restart, 'service[ucarp]'
-  end
+file "/etc/ucarp/vip-#{ucarp_databag['vip_id']}.pwd" do
+  content ucarp_databag['password']
+  owner 'root'
+  group 'root'
+  mode '0400'
+  notifies :restart, 'service[ucarp]'
+end
 
-  service 'ucarp' do
-    case node['ucarp']['init_type']
-    when 'systemd'
-      provider Chef::Provider::Service::Systemd
-      service_name "ucarp@vip-#{ucarp_databag['vip_id']}.service"
-    end
-    supports status: true, restart: true
-    action [:start, :enable]
+template "/etc/ucarp/vip-#{ucarp_databag['vip_id']}.conf" do
+  source 'vip.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  variables ucarp_databag.to_hash
+  notifies :restart, 'service[ucarp]'
+end
+
+service 'ucarp' do
+  case node['ucarp']['init_type']
+  when 'systemd'
+    provider Chef::Provider::Service::Systemd
+    service_name "ucarp@vip-#{ucarp_databag['vip_id']}.service"
   end
+  supports status: true, restart: true
+  action [:start, :enable]
 end

--- a/recipes/remove.rb
+++ b/recipes/remove.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook:: ucarp
+# Recipe:: remove
+#
+# Copyright:: 2018, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ucarp_databag = begin
+                  data_bag_item('ucarp', node['ucarp']['data_bag']['cluster'])
+                rescue
+                  nil
+                end
+
+unless ucarp_databag.nil?
+  # Prevent notifications from restarting service after it's already been removed
+  pwd_r  = find_resource(:file,     "/etc/ucarp/vip-#{ucarp_databag['vip_id']}.pwd")
+  conf_r = find_resource(:template, "/etc/ucarp/vip-#{ucarp_databag['vip_id']}.conf")
+  run_context.delayed_notification_collection.delete(pwd_r.declared_key)
+  run_context.delayed_notification_collection.delete(conf_r.declared_key)
+
+  edit_resource(:file, "/etc/ucarp/vip-#{ucarp_databag['vip_id']}.pwd") do
+    action :delete
+  end
+
+  edit_resource(:template, "/etc/ucarp/vip-#{ucarp_databag['vip_id']}.conf") do
+    action :delete
+  end
+end
+
+edit_resource(:service, 'ucarp') do
+  action [:stop, :disable]
+end
+
+edit_resource(:package, 'ucarp') do
+  action :remove
+end
+
+# Remove patched file
+edit_resource(:cookbook_file, '/usr/libexec/ucarp/ucarp') do
+  action :delete
+end

--- a/spec/databag_spec.rb
+++ b/spec/databag_spec.rb
@@ -1,18 +1,52 @@
 require_relative 'spec_helper'
 
 describe 'ucarp::data_bag' do
-  ALL_PLATFORMS.each do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new do |node|
-        node.normal['ucarp']['data_bag']['cluster'] = 'lb1'
-        node.normal['ucarp']['init_type'] = 'systemd'
-      end.converge(described_recipe)
-    end
+  ALL_PLATFORMS.each do |plat|
+    context "#{plat[:platform]} #{plat[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(plat) do |node|
+          node.normal['ucarp']['data_bag']['cluster'] = 'lb1'
+          node.normal['ucarp']['init_type'] = 'systemd'
+        end.converge(described_recipe)
+      end
 
-    include_context 'common_stubs'
+      include_context 'common_stubs'
 
-    it do
-      expect { chef_run }.to_not raise_error
+      it do
+        expect { chef_run }.to_not raise_error
+      end
+      it do
+        expect(chef_run).to create_file('/etc/ucarp/vip-001.pwd').with(
+          content: 'secret',
+          owner: 'root',
+          group: 'root',
+          mode: '0400'
+        )
+      end
+      it do
+        expect(chef_run.file('/etc/ucarp/vip-001.pwd')).to notify('service[ucarp]').to(:restart)
+      end
+      it do
+        expect(chef_run).to create_template('/etc/ucarp/vip-001.conf').with(
+          source: 'vip.conf.erb',
+          owner: 'root',
+          group: 'root',
+          mode: '0644'
+        )
+      end
+      it do
+        expect(chef_run.template('/etc/ucarp/vip-001.conf')).to notify('service[ucarp]').to(:restart)
+      end
+      it do
+        expect(chef_run).to start_service('ucarp').with(
+          supports: { status: true, restart: true }
+        )
+      end
+      it do
+        expect(chef_run).to enable_service('ucarp').with(
+          supports: { status: true, restart: true }
+        )
+      end
     end
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,29 +1,24 @@
 require_relative 'spec_helper'
 
 describe 'ucarp::default' do
-  ALL_PLATFORMS.each do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new do |node|
-        node.normal['platform_family'] = 'rhel'
-      end.converge(described_recipe)
-    end
-
-    context 'on both rhel and non-rhel distros' do
+  ALL_PLATFORMS.each do |plat|
+    context "#{plat[:platform]} #{plat[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(plat).converge(described_recipe)
+      end
       it do
         expect(chef_run).to install_package('ucarp')
       end
-    end
-
-    it do
-      resource = chef_run.service('networking')
-      expect(resource).to do_nothing
-    end
-
-    it do
-      template_resource = chef_run.template('/etc/network/interfaces')
-      expect(template_resource).to notify(
-        'service[networking]'
-      ).to(:restart).immediately
+      if plat[:version].to_i == 7
+        it do
+          expect(chef_run).to create_cookbook_file('/usr/libexec/ucarp/ucarp').with(
+            source: 'ucarp',
+            owner: 'root',
+            group: 'root',
+            mode: '0700'
+          )
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,25 +5,17 @@ ChefSpec::Coverage.start! { add_filter 'ucarp' }
 
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.3',
-  platform_family: 'rhel'
+  version: '7.2.1511'
 }.freeze
 
 CENTOS_6 = {
   platform: 'centos',
-  version: '6.8',
-  platform_family: 'rhel'
-}.freeze
-
-DEBIAN_8 = {
-  platform: 'debian',
-  version: '8.4'
+  version: '6.8'
 }.freeze
 
 ALL_PLATFORMS = [
   CENTOS_6,
-  CENTOS_7,
-  DEBIAN_8
+  CENTOS_7
 ].freeze
 
 RSpec.configure do |config|
@@ -32,11 +24,6 @@ end
 
 shared_context 'common_stubs' do
   before do
-    stub_command 'ip addr flush dev eth0'
-    stub_command 'ip addr flush dev eth1'
-    stub_command 'flush ip on eth0'
-    stub_command 'flush ip on eth1'
-
     stub_data_bag_item('ucarp', 'lb1').and_return(
       id: 'vip-lb1',
       vip_id: '001',

--- a/test/integration/data_bag/serverspec/server_spec.rb
+++ b/test/integration/data_bag/serverspec/server_spec.rb
@@ -10,10 +10,21 @@ describe file('/etc/ucarp/vip-001.conf') do
   its(:content) { should match(/PASSWORD=secret/) }
 end
 
+describe file('/etc/ucarp/vip-001.pwd') do
+  its(:content) { should match(/secret/) }
+  it { should be_owned_by     'root' }
+  it { should be_grouped_into 'root' }
+  it { should be_mode 400 }
+end
+
 describe package('ucarp') do
   it { should be_installed }
 end
 
-describe service('ucarp@vip-001') do
+service_name = 'ucarp@vip-001' if os[:family] == 'redhat' && os[:release].to_i == 7
+service_name = 'ucarp'         if os[:family] == 'redhat' && os[:release].to_i == 6
+
+describe service service_name do
   it { should be_enabled }
+  it { should be_running }
 end

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -6,6 +6,13 @@ describe package('ucarp') do
   it { should be_installed }
 end
 
-describe service('ucarp') do
-  it { should be_enabled }
+if os[:family] == 'redhat' && os[:release].to_i == 7
+  describe file('/usr/libexec/ucarp/ucarp') do
+    # Test for patched line for
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1568599
+    its(:content) { should match(/^    FILES=`find \${CONFDIR} -maxdepth 1 -type f -name "\${_cfg}.conf" \\$/) }
+    it { should be_mode 700 }
+    it { should be_owned_by     'root' }
+    it { should be_grouped_into 'root' }
+  end
 end

--- a/test/integration/remove/serverspec/remove_spec.rb
+++ b/test/integration/remove/serverspec/remove_spec.rb
@@ -1,0 +1,22 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe package 'ucarp' do
+  it { should_not be_installed }
+end
+
+describe service 'ucarp' do
+  it { should_not be_enabled }
+  it { should_not be_running }
+end
+
+%w(
+  /usr/libexec/ucarp/ucarp
+  /etc/ucarp/vip-001.conf
+  /etc/ucarp/vip-001.pwd
+). each do |f|
+  describe file f do
+    it { should_not exist }
+  end
+end


### PR DESCRIPTION
This adds a recipe for removing ucarp (which will be used when cutting over to keepalived).

This also addresses several problems with the cookbook:
* `/usr/libexec/ucarp/ucarp` is patched for CentOS 7 to deal with https://bugzilla.redhat.com/show_bug.cgi?id=1568599 (even though it seems like this should already be fixed upstream...)
* Data bags generate `/etc/ucarp/vip-XXX.pwd` (a password file) so ucarp doesn't complain about wanting a `PASSFILE` instead of a `PASSWORD`
* Ubuntu and Debian support is removed, as we don't use that in production, and won't in the future

`ucarp::remove` ~~rewinds~~ edits `service[ucarp]` to ignore failure because otherwise the notifications from creating/deleting `vip-XXX.pwd` and `vip-XXX.conf` try to restart the ucarp service after it no longer exists. Making the notifications `:immediate` isn't viable, as then the service fails to start because one of the two files isn't in place for the first restart. If there's a better way to address this, suggestions are welcome.